### PR TITLE
Update astroport ANS to use incentives instead of generator

### DIFF
--- a/src/clients/astroport/AstroportFactory.client.ts
+++ b/src/clients/astroport/AstroportFactory.client.ts
@@ -102,13 +102,13 @@ export interface AstroportFactoryInterface extends AstroportFactoryReadOnlyInter
     {
       coinRegistryAddress,
       feeAddress,
-      generatorAddress,
+      incentivesAddress,
       tokenCodeId,
       whitelistCodeId,
     }: {
       coinRegistryAddress?: string
       feeAddress?: string
-      generatorAddress?: string
+      incentivesAddress?: string
       tokenCodeId?: number
       whitelistCodeId?: number
     },
@@ -211,13 +211,13 @@ export class AstroportFactoryClient
     {
       coinRegistryAddress,
       feeAddress,
-      generatorAddress,
+      incentivesAddress,
       tokenCodeId,
       whitelistCodeId,
     }: {
       coinRegistryAddress?: string
       feeAddress?: string
-      generatorAddress?: string
+      incentivesAddress?: string
       tokenCodeId?: number
       whitelistCodeId?: number
     },
@@ -232,7 +232,7 @@ export class AstroportFactoryClient
         update_config: {
           coin_registry_address: coinRegistryAddress,
           fee_address: feeAddress,
-          generator_address: generatorAddress,
+          incentives_address: incentivesAddress,
           token_code_id: tokenCodeId,
           whitelist_code_id: whitelistCodeId,
         },

--- a/src/clients/astroport/AstroportFactory.types.ts
+++ b/src/clients/astroport/AstroportFactory.types.ts
@@ -21,7 +21,7 @@ export type PairType =
 export interface InstantiateMsg {
   coin_registry_address: string
   fee_address?: string | null
-  generator_address?: string | null
+  incentives_address?: string | null
   owner: string
   pair_configs: PairConfig[]
   token_code_id: number
@@ -42,7 +42,7 @@ export type ExecuteMsg =
       update_config: {
         coin_registry_address?: string | null
         fee_address?: string | null
-        generator_address?: string | null
+        incentives_address?: string | null
         token_code_id?: number | null
         whitelist_code_id?: number | null
       }
@@ -130,7 +130,7 @@ export type ArrayOfPairType = PairType[]
 export interface ConfigResponse {
   coin_registry_address: Addr
   fee_address?: Addr | null
-  generator_address?: Addr | null
+  incentives_address?: Addr | null
   owner: Addr
   pair_configs: PairConfig[]
   token_code_id: number

--- a/src/exchanges/astroport.ts
+++ b/src/exchanges/astroport.ts
@@ -126,11 +126,11 @@ export class Astroport extends Exchange {
   async registerPools(network: Network) {
     const astroContracts = await this.retrieveAstroContracts()
 
-    if (!astroContracts.generator_address) {
+    if (!astroContracts.incentives_address) {
       throw new Error('Could not find generator address')
     }
 
-    const { generator_address: stakingAddress } = astroContracts
+    const { incentives_address: stakingAddress } = astroContracts
 
     const pairs = await this.fetchTopPairs(network)
 
@@ -201,11 +201,11 @@ export class Astroport extends Exchange {
   async registerContracts(network: Network) {
     // const astroContracts = await this.retrieveAstroContracts()
     //
-    // if (!astroContracts.generator_address) {
+    // if (!astroContracts.incentives_address) {
     //   throw new Error('Could not find generator address')
     // }
     //
-    // const { generator_address: stakingAddress } = astroContracts
+    // const { incentives_address: stakingAddress } = astroContracts
     //
     // const { pools } = await this.fetchPoolList(network)
     //
@@ -237,7 +237,7 @@ export class Astroport extends Exchange {
   }
 
   private async retrieveAstroContracts(): Promise<{
-    generator_address: string
+    incentives_address: string
     factory_address: string
     astro_token_address: string
     [k: string]: string

--- a/src/exchanges/astroportgql.ts
+++ b/src/exchanges/astroportgql.ts
@@ -33,7 +33,7 @@ interface AstroportOptions {
   graphQlEndpoint: string
   astroContractsOverrides?: {
     astro_token_address?: string
-    generator_address?: string
+    incentives_address?: string
   }
 }
 
@@ -113,11 +113,11 @@ export class AstroportGql extends Exchange {
   async registerPools(network: Network) {
     const astroContracts = await this.retrieveAstroContracts()
 
-    if (!astroContracts.generator_address) {
+    if (!astroContracts.incentives_address) {
       throw new Error('Could not find generator address')
     }
 
-    const { generator_address: stakingAddress } = astroContracts
+    const { incentives_address: stakingAddress } = astroContracts
 
     const { pools } = await this.fetchGraphql(network)
 
@@ -159,7 +159,7 @@ export class AstroportGql extends Exchange {
   async registerContracts(network: Network) {}
 
   private async retrieveAstroContracts(): Promise<{
-    generator_address: string
+    incentives_address: string
     factory_address: string
     astro_token_address: string
     [k: string]: string

--- a/wynd2.ts
+++ b/wynd2.ts
@@ -89,11 +89,11 @@ export class Wyndex extends Exchange {
   async registerPools(network: Network) {
     const astroContracts = await this.retrieveAstroContracts()
 
-    if (!astroContracts.generator_address) {
+    if (!astroContracts.incentives_address) {
       throw new Error('Could not find generator address')
     }
 
-    const { generator_address: stakingAddress } = astroContracts
+    const { incentives_address: stakingAddress } = astroContracts
 
     const pairs = await this.fetchTopPairs(network)
 
@@ -164,11 +164,11 @@ export class Wyndex extends Exchange {
   async registerContracts(network: Network) {
     // const astroContracts = await this.retrieveAstroContracts()
     //
-    // if (!astroContracts.generator_address) {
+    // if (!astroContracts.incentives_address) {
     //   throw new Error('Could not find generator address')
     // }
     //
-    // const { generator_address: stakingAddress } = astroContracts
+    // const { incentives_address: stakingAddress } = astroContracts
     //
     // const { pools } = await this.fetchPoolList(network)
     //


### PR DESCRIPTION
Astroport added new contract `incentives` for staking, that replaces `generator` contract. 

- [x] Will open PR after testnets addresses gets updated as well, see: https://github.com/astroport-fi/astroport-changelog/issues/4

Closes ABS-335